### PR TITLE
[THA-1395] fix: view function result word break

### DIFF
--- a/components/RunCard.tsx
+++ b/components/RunCard.tsx
@@ -130,7 +130,7 @@ export function RunCard({ id }: { id: string }) {
                       href={`https://explorer.aptoslabs.com/txn/${executionResult}?network=${network}`}>{executionResult}
                     </Link>
                   </Text> :
-                  <Text>Result: {executionResult}</Text>
+                  <Text wordBreak={"break-word"}>Result: {executionResult}</Text>
               }
             </Box>}
 


### PR DESCRIPTION
word would break, instead of making the card very long.

![image](https://github.com/ThalaLabs/thala-run/assets/19623228/80645189-5ec6-4cf5-abc4-14a392106954)
